### PR TITLE
fix links to python docs

### DIFF
--- a/pages/docs/developers/python.vue
+++ b/pages/docs/developers/python.vue
@@ -6,9 +6,9 @@ order: 2
 ---
 <template lang='md'>
 
-  [![](~/assets/docs/various/python-api.png)](https://pyspeckle-test.readthedocs.io/en/latest/quickstart.html)
+  [![](~/assets/docs/various/python-api.png)](https://pyspeckle.readthedocs.io/en/latest/quickstart.html)
 
-  Thanks to [Antoine Dao](https://twitter.com/ntoinedao?lang=en), the pyton documentation now (1) exists and (2) can [be found here!](https://pyspeckle-test.readthedocs.io/en/latest/quickstart.html)
+  Thanks to [Antoine Dao](https://github.com/AntoineDao), the pyton documentation now (1) exists and (2) can [be found here!](https://pyspeckle.readthedocs.io/en/latest/quickstart.html)
 
 </template>
 <script>


### PR DESCRIPTION
Set links to the `official` rather than test docs. Also, being pedantic but I prefer link to github rather than Twitter. I'm more interesting when I code rather than when I randomly like pictures of cats 🐱 